### PR TITLE
chore: use java helper for templates

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -14,12 +14,8 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
+import synthtool.languages.java as java
 
-common_templates = gcp.CommonTemplates()
-templates = common_templates.java_library()
-s.copy(templates, excludes=[
-    '.gitignore',
+java.common_templates(excludes=[
     'README.md',
 ])


### PR DESCRIPTION
We are cleaning up usage of common templates in synthtool. This allows us the cleanup usage in a centralized place rather than in 60+ repos