### PR TITLE
test: disable batch operation tests in ITDnsTest

### DIFF
--- a/src/test/java/com/google/cloud/dns/it/ITDnsTest.java
+++ b/src/test/java/com/google/cloud/dns/it/ITDnsTest.java
@@ -1269,6 +1269,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testListZonesBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -1439,6 +1440,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testCreateValidZoneBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -1614,6 +1616,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testGetZoneBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -1713,6 +1716,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testDeleteZoneBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -1729,6 +1733,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testGetProjectBatch() {
     // fetches all fields
     DnsBatch batch = DNS.batch();
@@ -1752,6 +1757,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testCreateChangeBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -1857,6 +1863,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testGetChangeBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -1941,6 +1948,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testListChangesBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -2071,6 +2079,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testListDnsRecordSetsBatch() {
     assumeFalse(IS_VPC_TEST);
     try {

--- a/src/test/java/com/google/cloud/dns/it/ITDnsTest.java
+++ b/src/test/java/com/google/cloud/dns/it/ITDnsTest.java
@@ -1503,6 +1503,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testCreateZoneWithOptionsBatch() {
     assumeFalse(IS_VPC_TEST);
     try {
@@ -2232,6 +2233,7 @@ public class ITDnsTest {
   }
 
   @Test
+  @Ignore
   public void testBatchCombined() {
     assumeFalse(IS_VPC_TEST);
     // only testing that the combination is possible


### PR DESCRIPTION
Fixes: #627.

Context: https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html