### PR TITLE
deps: use errorprone from shared deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.13.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The shared dependencies BOM provides the error_prone_annotations version. No need to specify in individual repositories.